### PR TITLE
Necessary patches for running rtree on real machines

### DIFF
--- a/drivers/md/dm-thin-metadata.c
+++ b/drivers/md/dm-thin-metadata.c
@@ -456,7 +456,7 @@ static int rtree_insert(void *context, dm_block_t block, dm_block_t data_block,
 	mapping.data_begin = data_block;
 	mapping.len = 1;
 	mapping.time = pmd->time;
-	*inserted = 0;		// TODO: stub
+	*inserted = 0;
 
 	return dm_rtree_insert(pmd->tm, pmd->data_sm, *root, &mapping, root,
 			       inserted);

--- a/drivers/md/dm-thin-metadata.c
+++ b/drivers/md/dm-thin-metadata.c
@@ -1205,9 +1205,6 @@ int dm_pool_metadata_close(struct dm_pool_metadata *pmd)
 	if (pmd->data_extents)
 		dm_extent_allocator_destroy(pmd->data_extents);
 
-	if (pmd->data_extents)
-		dm_extent_allocator_destroy(pmd->data_extents);
-
 	kfree(pmd);
 	return 0;
 }

--- a/drivers/md/dm-thin-metadata.h
+++ b/drivers/md/dm-thin-metadata.h
@@ -44,6 +44,7 @@ typedef uint64_t dm_thin_id;
  */
 struct dm_pool_metadata *dm_pool_metadata_open(struct block_device *bdev,
 					       sector_t data_block_size,
+					       bool use_rtree,
 					       bool format_device);
 
 int dm_pool_metadata_close(struct dm_pool_metadata *pmd);
@@ -54,7 +55,8 @@ int dm_pool_metadata_close(struct dm_pool_metadata *pmd);
  */
 #define THIN_FEATURE_COMPAT_SUPP	  0UL
 #define THIN_FEATURE_COMPAT_RO_SUPP	  0UL
-#define THIN_FEATURE_INCOMPAT_SUPP	  0UL
+#define THIN_FEATURE_INCOMPAT_SUPP	  1UL
+#define THIN_FEATURE_USE_RTREE		  1UL
 
 /*
  * Device creation/deletion.

--- a/drivers/md/dm-thin-metadata.h
+++ b/drivers/md/dm-thin-metadata.h
@@ -137,6 +137,7 @@ dm_thin_id dm_thin_dev_id(struct dm_thin_device *td);
 
 struct dm_thin_lookup_result {
 	dm_block_t block;
+	uint32_t len;
 	bool shared:1;
 };
 

--- a/drivers/md/persistent-data/dm-extent-allocator.c
+++ b/drivers/md/persistent-data/dm-extent-allocator.c
@@ -65,7 +65,7 @@ struct node {
 #define SPLIT_THRESHOLD 16
 
 struct dm_extent_allocator {
-	spinlock_t lock;
+	struct mutex lock;
 
 	unsigned nr_preallocated_nodes;
 	unsigned nr_free_nodes;
@@ -80,12 +80,12 @@ struct dm_extent_allocator {
 
 static void lock(struct dm_extent_allocator *ea)
 {
-	spin_lock(&ea->lock);
+	mutex_lock(&ea->lock);
 }
 
 static void unlock(struct dm_extent_allocator *ea)
 {
-	spin_unlock(&ea->lock);
+	mutex_unlock(&ea->lock);
 }
 
 /**
@@ -244,7 +244,7 @@ struct dm_extent_allocator *dm_extent_allocator_create(uint64_t nr_blocks)
 	if (!ea)
 		return NULL;
 
-	spin_lock_init(&ea->lock);
+	mutex_init(&ea->lock);
 	ea->nr_blocks = nr_blocks;
 	ea->nr_preallocated_nodes = 0;
 	ea->nr_free_nodes = 0;

--- a/drivers/md/persistent-data/dm-extent-allocator.c
+++ b/drivers/md/persistent-data/dm-extent-allocator.c
@@ -142,12 +142,12 @@ static void __free_tree(struct dm_extent_allocator *ea, struct node *n)
 	if (!n)
 		return;
 
-	if (n->is_leaf)
-		__free_node(ea, n);
-	else {
+	if (!n->is_leaf) {
 		__free_tree(ea, n->u.internal.left);
 		__free_tree(ea, n->u.internal.right);
 	}
+
+	__free_node(ea, n);
 }
 
 /**

--- a/drivers/md/persistent-data/dm-rtree.c
+++ b/drivers/md/persistent-data/dm-rtree.c
@@ -1718,7 +1718,7 @@ int dm_rtree_lookup(struct dm_transaction_manager *tm, dm_block_t root,
 			get_mapping(n, i, result);
 			thin_end = result->thin_begin + result->len;
 
-			if (key > thin_end) {
+			if (key >= thin_end) {
 				dm_tm_unlock(tm, b);
 				return -ENODATA;
 			}

--- a/drivers/md/persistent-data/dm-rtree.h
+++ b/drivers/md/persistent-data/dm-rtree.h
@@ -71,6 +71,12 @@ int dm_rtree_lookup(struct dm_transaction_manager *tm, dm_block_t root,
 		    dm_block_t key, struct dm_mapping *result);
 
 /**
+ * dm_rtree_look_next - Find the first key which is not less than the given one.
+ */
+int dm_rtree_lookup_next(struct dm_transaction_manager *tm, dm_block_t root,
+		         dm_block_t key, struct dm_mapping *result);
+
+/**
  * dm_rtree_insert - Insert or overwrite a value in an rtree.
  *
  * @tm: The transaction manager to use.


### PR DESCRIPTION
- Fix data block ref counts while overwriting: Allow updating the timestamp without remapping data blocks.
- Make rtree an optional feature to dm-thin via table flags, and parameterize the interface to rtree and btree.
- Complete missing features: dm_rtree_lookup_next, dm_rtree_find_highest_key
- Bug fixes: nr_mapped_blocks in details tree; double free on extent allocator.